### PR TITLE
Ghi025 ifkey

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -252,7 +252,7 @@ func (gs *State) MoveNPCs() {
 		room := gs.World[roomLabel]
 		npc := room.NPCs[npcLabel]
 
-		next := npc.NextRouteStep(room)
+		next := npc.NextRouteStep(room, &gs.scripts)
 
 		if next != "" {
 			nextRoom := gs.World[next]

--- a/internal/game/item.go
+++ b/internal/game/item.go
@@ -62,7 +62,7 @@ type Item struct {
 	// explicitly given.
 	Aliases []string
 
-	// If is the tunascript that is evaluated to determine if this egress is
+	// If is the tunascript that is evaluated to determine if this item is
 	// interactable and visible to the user. If IfRaw is empty, this will be an
 	// expression that always returns true.
 	If tunascript.AST

--- a/internal/game/item.go
+++ b/internal/game/item.go
@@ -62,6 +62,16 @@ type Item struct {
 	// explicitly given.
 	Aliases []string
 
+	// If is the tunascript that is evaluated to determine if this egress is
+	// interactable and visible to the user. If IfRaw is empty, this will be an
+	// expression that always returns true.
+	If tunascript.AST
+
+	// IfRaw is the string that contains the TunaScript source code that was
+	// parsed into the AST located in If. It will be empty if no code was parsed
+	// to do so.
+	IfRaw string
+
 	// tmplDescription is the precomputed template AST for the description text.
 	// It must generally be filled in with the game engine, and will not be
 	// present directly when loaded from disk.

--- a/internal/game/item.go
+++ b/internal/game/item.go
@@ -89,6 +89,8 @@ func (item Item) Copy() Item {
 		Name:        item.Name,
 		Description: item.Description,
 		Aliases:     make([]string, len(item.Aliases)),
+		If:          item.If,
+		IfRaw:       item.IfRaw,
 
 		tmplDescription: item.tmplDescription,
 	}

--- a/internal/game/npc.go
+++ b/internal/game/npc.go
@@ -46,6 +46,16 @@ type NPC struct {
 	// NPC.
 	Convo *Conversation
 
+	// If is the tunascript that is evaluated to determine if this NPC is
+	// interactable and visible to the user. If IfRaw is empty, this will be an
+	// expression that always returns true.
+	If tunascript.AST
+
+	// IfRaw is the string that contains the TunaScript source code that was
+	// parsed into the AST located in If. It will be empty if no code was parsed
+	// to do so.
+	IfRaw string
+
 	// for NPCs with a path movement route, routeCur gives the step it is
 	// currently on.
 	routeCur *int

--- a/internal/game/npc.go
+++ b/internal/game/npc.go
@@ -145,6 +145,8 @@ func (npc NPC) Copy() NPC {
 		Movement:    npc.Movement.Copy(),
 		Dialog:      make([]*DialogStep, len(npc.Dialog)),
 		Aliases:     make([]string, len(npc.Aliases)),
+		If:          npc.If,
+		IfRaw:       npc.IfRaw,
 
 		tmplDescription: npc.tmplDescription,
 	}

--- a/internal/game/npc.go
+++ b/internal/game/npc.go
@@ -65,10 +65,11 @@ func (npc *NPC) ResetRoute() {
 
 // NextRouteStep gets the name of the next location this character would like to
 // travel to. If it returns an empty string, the NPC's route dictates that they
-// should stay.
+// should stay. The tsInterpreter engine, if provided, is used to evaluate which
+// exits are visible/usable to this NPC.
 //
 // room is the current room that they are in.
-func (npc NPC) NextRouteStep(room *Room) string {
+func (npc NPC) NextRouteStep(room *Room, tsEng *tunascript.Interpreter) string {
 	if npc.routeCur == nil {
 		return ""
 	}
@@ -84,7 +85,8 @@ func (npc NPC) NextRouteStep(room *Room) string {
 		// first, get the list of allowed rooms. if allowedrooms is not set,
 		// all rooms are allowed.
 		candidateRooms := map[string]bool{}
-		for _, egress := range room.Exits {
+		availExits := room.ExitsAvailable(npc.Label, tsEng)
+		for _, egress := range availExits {
 			label := egress.DestLabel
 
 			if len(npc.Movement.AllowedRooms) > 0 {

--- a/internal/game/room.go
+++ b/internal/game/room.go
@@ -72,6 +72,16 @@ type Egress struct {
 	// prevent spoilerific room names.
 	Aliases []string
 
+	// If is the tunascript that is evaluated to determine if this egress is
+	// interactable and visible to the user. If IfRaw is empty, this will be an
+	// expression that always returns true.
+	If tunascript.AST
+
+	// IfRaw is the string that contains the TunaScript source code that was
+	// parsed into the AST located in If. It will be empty if no code was parsed
+	// to do so.
+	IfRaw string
+
 	// tmplDescription is the precomputed template AST for the description text.
 	// It must generally be filled in with the game engine, and will not be
 	// present directly when loaded from disk.

--- a/internal/tqw/marshaledtypes.go
+++ b/internal/tqw/marshaledtypes.go
@@ -218,6 +218,7 @@ type egress struct {
 	Description string   `toml:"description"`
 	Message     string   `toml:"message"`
 	Aliases     []string `toml:"aliases"`
+	If          string   `toml:"if"`
 }
 
 func (te egress) toGameEgress() game.Egress {
@@ -226,6 +227,7 @@ func (te egress) toGameEgress() game.Egress {
 		Description:   te.Description,
 		TravelMessage: te.Message,
 		Aliases:       make([]string, len(te.Aliases)),
+		IfRaw:         te.If,
 	}
 
 	for i := range te.Aliases {

--- a/internal/tqw/marshaledtypes.go
+++ b/internal/tqw/marshaledtypes.go
@@ -196,6 +196,7 @@ type item struct {
 	Description string   `toml:"description"`
 	Aliases     []string `toml:"aliases"`
 	Start       string   `toml:"start"`
+	If          string   `toml:"if"`
 }
 
 func (ti item) toGameItem() game.Item {
@@ -204,6 +205,7 @@ func (ti item) toGameItem() game.Item {
 		Name:        ti.Name,
 		Description: ti.Description,
 		Aliases:     make([]string, len(ti.Aliases)),
+		IfRaw:       ti.If,
 	}
 
 	for i := range ti.Aliases {

--- a/internal/tqw/marshaledtypes.go
+++ b/internal/tqw/marshaledtypes.go
@@ -244,12 +244,14 @@ func (te egress) toGameEgress() game.Egress {
 type detail struct {
 	Aliases     []string `toml:"aliases"`
 	Description string   `toml:"description"`
+	If          string   `toml:"if"`
 }
 
 func (td detail) toGameDetail() game.Detail {
 	det := game.Detail{
 		Aliases:     make([]string, len(td.Aliases)),
 		Description: td.Description,
+		IfRaw:       td.If,
 	}
 
 	for i := range det.Aliases {

--- a/internal/tqw/marshaledtypes.go
+++ b/internal/tqw/marshaledtypes.go
@@ -42,6 +42,7 @@ type npc struct {
 	Start       string       `toml:"start"`
 	Movement    route        `toml:"movement"`
 	Dialogs     []dialogStep `toml:"line"`
+	If          string       `toml:"if"`
 }
 
 func (tn npc) toGameNPC() game.NPC {
@@ -54,6 +55,7 @@ func (tn npc) toGameNPC() game.NPC {
 		Movement:    tn.Movement.toGameRoute(),
 		Dialog:      make([]*game.DialogStep, len(tn.Dialogs)),
 		Aliases:     make([]string, len(tn.Aliases)),
+		IfRaw:       tn.If,
 	}
 
 	for i := range tn.Dialogs {

--- a/internal/tqw/parse.go
+++ b/internal/tqw/parse.go
@@ -181,8 +181,16 @@ func parseWorldData(tqw topLevelWorldData) (WorldData, error) {
 			npc.PronounSet = pronouns[strings.ToUpper(npc.Pronouns)]
 		}
 
-		// done parsing, NPC is good to go, add it to the world
 		gameNPC := npc.toGameNPC()
+
+		// done with main parsing of NPC, now parse its tunascript
+		raw, tsAST, err := parseTunascript(gameNPC.IfRaw, false)
+		if err != nil {
+			return world, fmt.Errorf("npcs[%q]: %w", npc.Label, err)
+		}
+		gameNPC.IfRaw = raw
+		gameNPC.If = tsAST
+
 		world.Rooms[gameNPC.Start].NPCs[gameNPC.Label] = &gameNPC
 	}
 

--- a/internal/tqw/parse.go
+++ b/internal/tqw/parse.go
@@ -112,6 +112,16 @@ func parseWorldData(tqw topLevelWorldData) (WorldData, error) {
 			room.Exits[i].If = tsAST
 		}
 
+		// run a parse on the tunascript and set the If of each detail
+		for i := range room.Details {
+			raw, tsAST, err := parseTunascript(room.Details[i].IfRaw, false)
+			if err != nil {
+				return world, fmt.Errorf("rooms[%q]: detail[%d]: %w", r.Label, i, err)
+			}
+			room.Details[i].IfRaw = raw
+			room.Details[i].If = tsAST
+		}
+
 		world.Rooms[r.Label] = &room
 	}
 

--- a/tunascript/syntax/hooks.go
+++ b/tunascript/syntax/hooks.go
@@ -61,10 +61,12 @@ func makeHookBinaryOp(op BinaryOperation) trans.Hook {
 func makeHookAssignBinary(op AssignmentOperation) trans.Hook {
 	return func(info trans.SetterInfo, args []interface{}) (interface{}, error) {
 		lexedIdent := args[0].(string)
+
+		fname := strings.TrimPrefix(strings.ToUpper(lexedIdent), "$")
 		value := args[1].(ASTNode)
 
 		node := AssignmentNode{
-			Flag:  lexedIdent,
+			Flag:  fname,
 			Value: value,
 			Op:    op,
 			src:   info.FirstToken,
@@ -78,8 +80,10 @@ func makeHookAssignUnary(op AssignmentOperation) trans.Hook {
 	return func(info trans.SetterInfo, args []interface{}) (interface{}, error) {
 		lexedIdent := args[0].(string)
 
+		fname := strings.TrimPrefix(strings.ToUpper(lexedIdent), "$")
+
 		node := AssignmentNode{
-			Flag: lexedIdent,
+			Flag: fname,
 			Op:   op,
 			src:  info.FirstToken,
 		}

--- a/tunascript/tunascript.go
+++ b/tunascript/tunascript.go
@@ -110,6 +110,45 @@ func ParseValue(s string) Value {
 	return syntax.ValueOf(s)
 }
 
+// Parse parses (but does not execute) TunaScript code. It will use fromFile in
+// error reporting; this can be left as "". The code is converted into an AST
+// for further examination.
+func Parse(code string, fromFile string) (ast AST, err error) {
+	tsFront := fe.Frontend(syntax.HooksTable, nil)
+
+	ast, _, err = tsFront.AnalyzeString(code)
+	if err != nil {
+
+		// wrap syntax errors so user of the Interpreter doesn't have to check
+		// for a special syntax error just to get the detailed syntax err info
+		if synErr, ok := err.(*syntaxerr.Error); ok {
+			return ast, fmt.Errorf("%s", synErr.MessageForFile(fromFile))
+		}
+	}
+
+	return ast, err
+}
+
+// ParseReader parses (but does not execute) TunaScript code in the given
+// reader. It will use fromFile in error reporting; this can be left as "". The
+// entire contents of the Reader are read as TS code, which is returned as an
+// AST for further examination.
+func ParseReader(r io.Reader, fromFile string) (ast AST, err error) {
+	tsFront := fe.Frontend(syntax.HooksTable, nil)
+
+	ast, _, err = tsFront.Analyze(r)
+	if err != nil {
+
+		// wrap syntax errors so user of the Interpreter doesn't have to check
+		// for a special syntax error just to get the detailed syntax err info
+		if synErr, ok := err.(*syntaxerr.Error); ok {
+			return ast, fmt.Errorf("%s", synErr.MessageForFile(fromFile))
+		}
+	}
+
+	return ast, err
+}
+
 type WorldInterface interface {
 
 	// InInventory returns whether the given label Item is in the player

--- a/tunascript/tunascript.go
+++ b/tunascript/tunascript.go
@@ -462,6 +462,13 @@ func (interp *Interpreter) AddFlag(label string, val string) error {
 	return nil
 }
 
+// RemoveFlag removes the current value of the flag with the given label. It
+// will no longer exist as a defined variable. If there is already no flag with
+// the given label, this function has no effect.
+func (interp *Interpreter) RemoveFlag(label string) {
+	delete(interp.flags, label)
+}
+
 // ListFlags returns a list of all flags, sorted.
 func (interp *Interpreter) ListFlags() []string {
 	flags := make([]string, len(interp.flags))

--- a/world/rooms/house.tqw
+++ b/world/rooms/house.tqw
@@ -19,12 +19,13 @@ label = "YOUR_ROOM"
 name = "your bedroom"
 description = '''
 You are standing in your bedroom. Perhaps you are a young person who only now, on your 13th birthday, will receive a
-name. You have a pretty WINDOW in the corner overlooking the world outside. There's a door leading to your bathroom to
-the east, and a door leading to the hall to the south.
+name.$[[IF $WINDOW_ACTIVE]] You have a pretty WINDOW in the corner overlooking the world outside.$[[ENDIF]] There's a
+door leading to your bathroom to the east, and a door leading to the hall to the south.
 '''
 
 [[room.detail]]
 aliases = ["WINDOW", "CORNER WINDOW"]
+if = "$WINDOW_ACTIVE"
 description = '''
 The streets are empty. Wind skims the voids keeping neighbors apart, as if grazing the hollow of a cut reed, or say, a
 plundered mailbox. A familiar note is produced. It's the one Desolation plays to keep its instrument in tune.

--- a/world/rooms/house.tqw
+++ b/world/rooms/house.tqw
@@ -9,6 +9,7 @@ name = "pogo hammer"
 description = '''
 A hammer combined with a pogo-stick. What could go wrong?
 '''
+if = "$POGO_VISIBLE"
 start = "YOUR_ROOM"
 
 

--- a/world/rooms/house.tqw
+++ b/world/rooms/house.tqw
@@ -37,6 +37,7 @@ You have a feeling it's going to be a long day.
 aliases = ["BATHROOM", "TOILET", "DOOR", "EAST", "BATHROOM DOOR"]
 dest = "BATHROOM"
 description = "your $FANCY_BATHROOM_NAME door"
+if = "$BATHROOM_OPEN"
 message = '''
 You go through the door and enter the bathroom.
 '''

--- a/world/world.tqw
+++ b/world/world.tqw
@@ -32,3 +32,8 @@ default = "SOME PLAYER"
 [[flag]]
 label = "JOEY_PLAYER_HELLO"
 default = "What's up"
+
+[[flag]]
+label = "BATHROOM_OPEN"
+default = on
+

--- a/world/world.tqw
+++ b/world/world.tqw
@@ -35,5 +35,8 @@ default = "What's up"
 
 [[flag]]
 label = "BATHROOM_OPEN"
-default = on
+default = true
 
+[[flag]]
+label = "POGO_VISIBLE"
+default = true


### PR DESCRIPTION
- Adds if-key to NPCs, Items, Egresses, and Details.
- When the If is evaluated, `$TQ_ASKER` is set to one of `@PLAYER` if it's for the player to know/use, `@SELF` specifically in the case of an NPC checking their own visibility during movement, or the label of the entity for whom it is relevant. The tunascript within If may use this to return different visibilities depending on "who is asking", to do things such as an NPC that can move, but is invisible to the player. 
- Fixed bug in Tunascript where flags set via assignment operators would have the leading "$" as part of the flag name.